### PR TITLE
 Pull Request: Add cwd (Current Working Directory) Support to Utils

### DIFF
--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -1,43 +1,47 @@
 import simpleGit, { SimpleGit } from "simple-git";
 
-const git: SimpleGit = simpleGit();
+/**
+ * Create a SimpleGit instance with optional working directory (cwd).
+ */
+function getGit(cwd?: string): SimpleGit {
+  return simpleGit({ baseDir: cwd || process.cwd() });
+}
 
 /**
  * Returns the git diff of staged changes. If none, falls back to unstaged.
  */
-export async function getGitDiff(): Promise<string> {
-  // --staged gives diff of staged files. If nothing staged, diff returns empty.
+export async function getGitDiff(cwd?: string): Promise<string> {
+  const git = getGit(cwd);
   const stagedDiff = await git.diff(["--cached"]);
   if (stagedDiff.trim()) return stagedDiff;
 
-  // Get unstaged diff
   const workingDiff = await git.diff();
   return workingDiff.trim();
 }
 
 /**
- * Stage all modified and untracked files (equivalent to `git add -A`).
+ * Stage all modified and untracked files.
  */
-export async function stageAllChanges(): Promise<void> {
+export async function stageAllChanges(cwd?: string): Promise<void> {
+  const git = getGit(cwd);
   await git.add(["-A"]);
 }
 
 /**
- * Commit with the provided message. Assumes desired files are staged. If not, will stage all changes first.
+ * Commit with the provided message.
  */
-export async function commitWithMessage(message: string): Promise<void> {
-  // If nothing staged, attempting commit will fail; ensure staging.
+export async function commitWithMessage(message: string, cwd?: string): Promise<void> {
+  const git = getGit(cwd);
   const staged = (await git.diff(["--cached"]))?.trim();
-  if (!staged) {
-    return;
-  }
+  if (!staged) return;
   await git.commit(message);
 }
 
 /**
  * Return list of changed (modified, created, deleted, renamed) but **unstaged** file paths.
  */
-export async function listUnstagedFiles(): Promise<string[]> {
+export async function listUnstagedFiles(cwd?: string): Promise<string[]> {
+  const git = getGit(cwd);
   const status = await git.status();
   return [
     ...status.modified,
@@ -50,7 +54,8 @@ export async function listUnstagedFiles(): Promise<string[]> {
 /**
  * Stage the provided files.
  */
-export async function stageFiles(files: string[]): Promise<void> {
+export async function stageFiles(files: string[], cwd?: string): Promise<void> {
   if (!files.length) return;
+  const git = getGit(cwd);
   await git.add(files);
 }


### PR DESCRIPTION
# 📦 Pull Request: Add `cwd` (Current Working Directory) Support to Utils

## Summary
This PR introduces support for passing a custom working directory (`cwd`) to the Git utility functions in `gcommit-ai`. This change ensures that Git operations are executed relative to a specified project path, which is essential for tools like VS Code extensions and other programmatic integrations.

---

## ✅ Changes Made
- Added optional `cwd` parameter to the following functions:
  - `getGitDiff(cwd?: string)`
  - `listUnstagedFiles(cwd?: string)`
  - `stageFiles(files: string[], cwd?: string)`
  - `commitWithMessage(message: string, cwd?: string)`
- Updated internal `simple-git` instances to be initialized with the provided `cwd`, falling back to the current working directory by default.

---

## 📌 Why This Matters
- Allows external tools (e.g., VS Code extensions) to explicitly control the Git working directory.
- Fixes issues where `gcommit-ai` fails when run from non-repo root locations.
- Enables multi-project or monorepo support more reliably.

---

## 🧪 Testing
- [x] Tested in a local Git repo with unstaged changes.
- [x] Verified that providing `cwd` works correctly in nested directories.
- [x] Confirmed that behavior is unchanged if `cwd` is not provided.

---

Let me know if you'd like help adding test coverage or updating documentation.
